### PR TITLE
Laravel 5.4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Instead, you may of course manually update your require block and run `composer 
 
 Once OpenTok Laravel is installed, you need to register the service provider. Open up `config/app.php` and add the following to the `providers` key.
 
-* `'Tomcorbett\OpentokLaravel\ServiceProvider'`
+* `Tomcorbett\OpentokLaravel\ServiceProvider::class`
 
 You can register the OpentokApi facade in the `aliases` key of your `config/app.php` file if you like.
 
-* `'OpentokApi' => 'Tomcorbett\OpentokLaravel\Facades\OpentokApi'`
+* `'OpentokApi' => Tomcorbett\OpentokLaravel\Facades\OpentokApi::class`
 
 ### Configuration
 
@@ -65,7 +65,7 @@ use OpenTok\Role;
 use OpenTokException;
 
 // get your API key from config
-$api_key = Config::get('opentok-laravel::api_key');
+$api_key = Config::get('opentok.api_key');
         
 // then create a token (session created in previous step)
 try {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "5.0.x|5.1.x|5.2.x",
+        "illuminate/support": "5.0.x|5.1.x|5.2.x|5.3.x|5.4.x",
         "opentok/opentok": "dev-hitlabs"
     },
     "autoload": {

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -27,7 +27,7 @@ class ServiceProvider extends BaseServiceProvider {
     {
         $this->publishes([$this->configPath() => config_path('opentok.php')], 'config');
 
-		$this->app['OpentokApi'] = $this->app->share(function($app) {
+        $this->app->singleton('OpentokApi', function($app) {
 			return new OpenTok(
 				$app['config']->get('opentok')['api_key'],
 				$app['config']->get('opentok')['api_secret']


### PR DESCRIPTION
I have updated the package to work with Laravel 5.4, since it was no longer usable out of the box due to the required illuminate/support version and share() being removed and replaced by singleton() in the code base.

